### PR TITLE
Fix docker registry url for registry.scality.com

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: "registry.scality.com/${{ github.repository }}/${{ github.repository }}:${{ github.event.inputs.tag }}"
+          tags: "registry.scality.com/openstack-actions-runner/openstack-actions-runner:${{ github.event.inputs.tag }}"
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
github.repository variable also contain the org name and not only the repo name