### PR TITLE
Restart service on config change

### DIFF
--- a/charts/openstack-actions-runner/templates/deployment.yaml
+++ b/charts/openstack-actions-runner/templates/deployment.yaml
@@ -10,8 +10,11 @@ spec:
       {{- include "openstack-actions-runner.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/settings: {{ include (print $.Template.BasePath "/settings.yml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Currently if we only make some changes on the config, the service does not restart and the new configuration are not took into account.

This pr add a little helm trick to ensure that we are always in sync with the settings.